### PR TITLE
Feature/display images and info

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,126 @@
-import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { BrowserRouter as Router } from 'react-router-dom';
 import { App } from './App';
+import { useFetch } from './hooks/apis/use-fetch';
+import getImageBlocksHelper from './utils/helpers/get-image-blocks';
 
-// this can be removed
-test('renders welcome text', () => {
-  render(<App />);
-  const welcome = screen.getByText(/Replace me/i);
-  expect(welcome).toBeInTheDocument();
+jest.mock('./utils/helpers/get-image-blocks');
+jest.mock('./components/Header/Header', () => ({
+  Header: () => <div>Header</div>,
+}));
+jest.mock('./components/ImageGrid/ImageGrid', () => ({
+  ImageGrid: () => <div>ImageGrid</div>,
+}));
+jest.mock('./components/InfoPanel/InfoPanel', () => ({
+  InfoPanel: () => <div>InfoPanel</div>,
+}));
+
+jest.mock('./hooks/apis/use-fetch', () => ({
+  useFetch: jest.fn(),
+}));
+
+describe('App Component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders loading state', () => {
+    (useFetch as jest.Mock).mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+    });
+    (getImageBlocksHelper as jest.Mock).mockReturnValue([]);
+
+    render(
+      <Router>
+        <App />
+      </Router>
+    );
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  test('renders error state', () => {
+    const errorMessage = 'Failed to fetch data';
+    (useFetch as jest.Mock).mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: errorMessage,
+    });
+    (getImageBlocksHelper as jest.Mock).mockReturnValue([]);
+
+    render(
+      <Router>
+        <App />
+      </Router>
+    );
+
+    expect(screen.getByText(errorMessage)).toBeInTheDocument();
+  });
+
+  test('renders components when data is loaded', async () => {
+    const mockData = { someData: 'test' };
+    const mockImageBlocks = [{ id: 1, imageUrl: 'test.jpg' }];
+    (useFetch as jest.Mock).mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      error: null,
+    });
+    (getImageBlocksHelper as jest.Mock).mockReturnValue(mockImageBlocks);
+
+    render(
+      <Router>
+        <App />
+      </Router>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Header')).toBeInTheDocument();
+      expect(screen.getByText('ImageGrid')).toBeInTheDocument();
+      expect(screen.getByText('InfoPanel')).toBeInTheDocument();
+    });
+  });
+
+  test('handles empty image blocks', async () => {
+    (useFetch as jest.Mock).mockReturnValue({
+      data: {},
+      isLoading: false,
+      error: null,
+    });
+    (getImageBlocksHelper as jest.Mock).mockReturnValue([]);
+
+    render(
+      <Router>
+        <App />
+      </Router>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('ImageGrid')).toBeInTheDocument();
+      expect(screen.getByText('InfoPanel')).toBeInTheDocument();
+    });
+  });
+
+  test('handles null data', async () => {
+    (useFetch as jest.Mock).mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+    });
+    (getImageBlocksHelper as jest.Mock).mockReturnValue([]);
+
+    render(
+      <Router>
+        <App />
+      </Router>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('ImageGrid')).toBeInTheDocument();
+      expect(screen.getByText('InfoPanel')).toBeInTheDocument();
+    });
+    expect(getImageBlocksHelper).not.toHaveBeenCalled();
+  });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,14 +6,26 @@ import { getBlocks } from './blocks';
 import { Header } from './components/Header/Header';
 import { InfoPanel } from './components/InfoPanel/InfoPanel';
 import { ImageGrid } from './components/ImageGrid/ImageGrid';
+import { useFetch } from './hooks/apis/use-fetch';
+import { useMemo } from 'react';
+import getImageBlocksHelper from './utils/helpers/get-image-blocks';
 
 export const App = () => {
+  const { data: block, isLoading, error } = useFetch(getBlocks);
+
+  const imageBlocks = useMemo(() => {
+    if (block) return getImageBlocksHelper(block);
+    return [];
+  }, [block, isLoading]);
+
   return (
     <Router>
       <Header />
       <main>
-        <ImageGrid />
-        <InfoPanel />
+        {error && <div>{error}</div>}
+        {isLoading && <p>Loading...</p>}
+        <ImageGrid imageBlocks={imageBlocks} />
+        <InfoPanel blocks={imageBlocks!} />
       </main>
     </Router>
   );

--- a/src/components/ImageGrid/ImageGrid.module.css
+++ b/src/components/ImageGrid/ImageGrid.module.css
@@ -1,3 +1,42 @@
 .imageGrid {
-  padding-right: 480px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 30px;
+  padding-right: 0;
+  width: calc(100vw - 480px);
+  max-width: 100%;
+  padding: 30px;
+}
+
+.imageContainer {
+  width: 100%;
+  height: 0;
+  padding-bottom: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.image {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.imageSelected {
+  border: 2px blue solid;
+}
+
+@media (min-width: 1230px) {
+  .imageGrid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .imageGrid {
+    width: 100%;
+  }
 }

--- a/src/components/ImageGrid/ImageGrid.tsx
+++ b/src/components/ImageGrid/ImageGrid.tsx
@@ -1,11 +1,39 @@
 import styles from './ImageGrid.module.css';
 
-import { Block } from '../../blocks';
+import { Link, useRouteMatch } from 'react-router-dom';
+import { ImageBlock } from '../../types/blocks';
 
 type ImageGridProps = {
-  data?: Block;
+  imageBlocks: ImageBlock[];
 };
 
 export const ImageGrid = (props: ImageGridProps) => {
-  return <div className={styles.imageGrid}>Replace me</div>;
+  const { imageBlocks = [] } = props;
+
+  const routMatch = useRouteMatch<{
+    blockId: string;
+  }>('/:blockId');
+
+  const blockId = routMatch?.params.blockId;
+
+  return (
+    <div className={styles.imageGrid}>
+      {imageBlocks.map((block) => (
+        <Link
+          key={block.id}
+          to={`/${block.id}`}
+          className={styles.imageContainer}
+        >
+          <img
+            src={block.options.url}
+            className={[
+              styles.image,
+              block.id === blockId && styles.imageSelected,
+            ].join(' ')}
+            alt={block.data.description}
+          />
+        </Link>
+      ))}
+    </div>
+  );
 };

--- a/src/components/ImageGrid/imageGrid.test.tsx
+++ b/src/components/ImageGrid/imageGrid.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import { ImageGrid } from './ImageGrid';
+import mockImageBlocks from '../../utils/mock-data/mock-image-blocks';
+
+describe('ImageGrid Component', () => {
+  test('- should render images and their descriptions', () => {
+    render(
+      <Router>
+        <ImageGrid imageBlocks={mockImageBlocks} />
+      </Router>
+    );
+
+    expect(
+      screen.getByAltText(mockImageBlocks[0].data.description)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByAltText(mockImageBlocks[1].data.description)
+    ).toBeInTheDocument();
+  });
+
+  test('- should apply the selected image style when blockId matches', () => {
+    render(
+      <Router>
+        <ImageGrid imageBlocks={mockImageBlocks} />
+      </Router>
+    );
+
+    const linkElements = screen.getAllByRole('link');
+    expect(linkElements[0]).toHaveClass('imageContainer');
+    expect(linkElements[1]).toHaveClass('imageContainer');
+  });
+
+  test('- should not display images when empty imageBlocks array', () => {
+    render(
+      <Router>
+        <ImageGrid imageBlocks={[]} />
+      </Router>
+    );
+
+    expect(
+      screen.queryByAltText(mockImageBlocks[0].data.description)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByAltText(mockImageBlocks[1].data.description)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/InfoPanel/InfoPanel.tsx
+++ b/src/components/InfoPanel/InfoPanel.tsx
@@ -1,31 +1,39 @@
+import { useRouteMatch } from 'react-router-dom';
 import styles from './InfoPanel.module.css';
 
+import { ImageBlock } from '../../types/blocks';
+
 type InfoPanelProps = {
-  id?: string;
-  description?: string;
-  dimensions?: string;
-  createdAt?: string;
+  blocks: ImageBlock[];
 };
 
 export const InfoPanel = (props: InfoPanelProps) => {
-  const { id, description, dimensions, createdAt } = props;
+  const { blocks } = props;
+  const routMatch = useRouteMatch<{
+    blockId: string;
+  }>('/:blockId');
 
-  if (!id) {
-    return <aside className={styles.panel}></aside>;
-  }
+  const blockId = routMatch?.params.blockId;
+
+  const foundBlock = blocks.find((d) => d.id === blockId);
+  if (!foundBlock) return <aside className={styles.panel}></aside>;
+
+  const { description, width, height, createdAt } = foundBlock.data;
 
   return (
     <aside className={styles.panel}>
       <h2 className={styles.heading}>Block info</h2>
       <dl>
         <dt className={styles.title}>ID:</dt>
-        <dd className={styles.details}>{id}</dd>
+        <dd className={styles.details}>{foundBlock.id}</dd>
 
         <dt className={styles.title}>Description:</dt>
         <dd className={styles.details}>{description}</dd>
 
         <dt className={styles.title}>Dimensions:</dt>
-        <dd className={styles.details}>{dimensions}</dd>
+        <dd className={styles.details}>
+          {width} x {height}
+        </dd>
 
         <dt className={styles.title}>Created at:</dt>
         <dd className={styles.details}>{createdAt}</dd>

--- a/src/components/InfoPanel/infoPanel.test.tsx
+++ b/src/components/InfoPanel/infoPanel.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { InfoPanel } from './InfoPanel';
+import { ImageBlock } from '../../types/blocks';
+import '@testing-library/jest-dom/extend-expect';
+import mockImageBlocks from '../../utils/mock-data/mock-image-blocks';
+
+describe('InfoPanel Component', () => {
+  test('- should render block details when a matching block is found', () => {
+    render(
+      <MemoryRouter initialEntries={['/1']}>
+        <InfoPanel blocks={mockImageBlocks} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Block info')).toBeInTheDocument();
+    expect(screen.getByText(/ID:/)).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText(/Description:/)).toBeInTheDocument();
+    expect(screen.getByText('Image 1 description')).toBeInTheDocument();
+    expect(screen.getByText(/Dimensions:/)).toBeInTheDocument();
+    expect(screen.getByText('800 x 600')).toBeInTheDocument();
+    expect(screen.getByText(/Created at:/)).toBeInTheDocument();
+    expect(screen.getByText('2024-08-04')).toBeInTheDocument();
+  });
+
+  test('- should render an empty panel when no matching block is found', () => {
+    render(
+      <MemoryRouter initialEntries={['/nonexistent']}>
+        <InfoPanel blocks={mockImageBlocks} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText(/Block info/)).not.toBeInTheDocument();
+  });
+
+  test('- should handle missing data', () => {
+    const brokenImageBlocks: ImageBlock[] = [
+      {
+        id: '3',
+        type: 'Image',
+        options: {
+          url: '',
+          align: 'center',
+          width: '100%',
+        },
+        data: {
+          description: '',
+          width: 0,
+          height: 0,
+          createdAt: '',
+        },
+      },
+    ];
+
+    render(
+      <MemoryRouter initialEntries={['/3']}>
+        <InfoPanel blocks={brokenImageBlocks} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/Block info/)).toBeInTheDocument();
+    expect(screen.getByText(/ID:/)).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText(/Description:/)).toBeInTheDocument();
+
+    expect(screen.getByText(/Dimensions:/)).toBeInTheDocument();
+    expect(screen.getByText('0 x 0')).toBeInTheDocument();
+    expect(screen.getByText(/Created at:/)).toBeInTheDocument();
+  });
+});

--- a/src/hooks/apis/use-fetch.ts
+++ b/src/hooks/apis/use-fetch.ts
@@ -1,0 +1,42 @@
+import { useState, useEffect } from 'react';
+
+type FetchState<T> = {
+  data: T | null;
+  isLoading: boolean;
+  error: string | null;
+};
+
+type FetchFunction<T> = () => T | Promise<T>;
+
+export function useFetch<T>(dataFunction: FetchFunction<T>): FetchState<T> {
+  const [data, setData] = useState<T | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const result = dataFunction();
+
+        if (result instanceof Promise) {
+          const data = await result;
+          setData(data);
+        } else {
+          setData(result);
+        }
+      } catch (err) {
+        if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError(String(err));
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [dataFunction]);
+
+  return { data, isLoading, error };
+}

--- a/src/types/blocks.ts
+++ b/src/types/blocks.ts
@@ -1,0 +1,16 @@
+import { Block } from '../blocks';
+
+export type ImageBlock = Omit<Block, 'options' | 'data'> & {
+  type: 'Image';
+  options: {
+    url: string;
+    align: string;
+    width: string;
+  };
+  data: {
+    description: string;
+    width: number;
+    height: number;
+    createdAt: string;
+  };
+};

--- a/src/utils/helpers/get-image-blocks.test.tsx
+++ b/src/utils/helpers/get-image-blocks.test.tsx
@@ -1,0 +1,82 @@
+import { Block, blocks } from '../../blocks';
+import { ImageBlock } from '../../types/blocks';
+import getImageBlocksHelper from './get-image-blocks';
+
+describe('getImageBlocksHelper', () => {
+  test('- should return an array of imageBlock', () => {
+    const imageBlock: ImageBlock = {
+      id: '1',
+      type: 'Image',
+      options: {
+        url: 'http://example.com/image.png',
+        align: 'center',
+        width: '100%',
+      },
+      data: {
+        description: 'An example image',
+        width: 800,
+        height: 600,
+        createdAt: '2024-08-04',
+      },
+    };
+
+    const result = getImageBlocksHelper(imageBlock);
+    expect(result).toEqual([imageBlock]);
+  });
+
+  test('- should return an array with multiple ImageBlocks from nested blocks', () => {
+    const imageBlock1: ImageBlock = {
+      id: '1',
+      type: 'Image',
+      options: {
+        url: 'http://example.com/image1.png',
+        align: 'center',
+        width: '100%',
+      },
+      data: {
+        description: 'First image',
+        width: 800,
+        height: 600,
+        createdAt: '2024-08-04',
+      },
+    };
+
+    const imageBlock2: ImageBlock = {
+      id: '2',
+      type: 'Image',
+      options: {
+        url: 'http://example.com/image2.png',
+        align: 'left',
+        width: '50%',
+      },
+      data: {
+        description: 'Second image',
+        width: 400,
+        height: 300,
+        createdAt: '2024-08-04',
+      },
+    };
+
+    const blockWithChildren: Block = {
+      id: '3',
+      type: 'Layout',
+      children: [imageBlock1, imageBlock2],
+    };
+
+    const result = getImageBlocksHelper(blockWithChildren);
+    expect(result).toEqual([imageBlock1, imageBlock2]);
+  });
+
+  test('- should return an empty array when there are no ImageBlocks', () => {
+    const nonImageBlock: Block = {
+      id: '1',
+      type: 'PlainText',
+      data: {
+        text: 'This is a plain text block',
+      },
+    };
+
+    const result = getImageBlocksHelper(nonImageBlock);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/utils/helpers/get-image-blocks.ts
+++ b/src/utils/helpers/get-image-blocks.ts
@@ -1,0 +1,29 @@
+import { Block } from '../../blocks';
+import { ImageBlock } from '../../types/blocks';
+
+const getImageBlocksHelper = (block: Block): ImageBlock[] => {
+  const isImageBlock = (block: Block): block is ImageBlock =>
+    block.type === 'Image';
+
+  const getImageBlocksFromBlock = (block: Block): ImageBlock[] => {
+    const imageBlocks: ImageBlock[] = [];
+
+    if (isImageBlock(block)) {
+      imageBlocks.push(block);
+    }
+
+    if (block.children) {
+      imageBlocks.push(...block.children.flatMap(getImageBlocksFromBlock));
+    }
+
+    return imageBlocks;
+  };
+
+  const getImageBlocks = (blocks: Block[]): ImageBlock[] =>
+    blocks.flatMap(getImageBlocksFromBlock);
+
+  const imageBlocks: ImageBlock[] = getImageBlocks([block]);
+  return imageBlocks;
+};
+
+export default getImageBlocksHelper;

--- a/src/utils/mock-data/mock-image-blocks.ts
+++ b/src/utils/mock-data/mock-image-blocks.ts
@@ -1,0 +1,36 @@
+import { ImageBlock } from '../../types/blocks';
+
+const mockImageBlocks: ImageBlock[] = [
+  {
+    id: '1',
+    type: 'Image',
+    options: {
+      url: 'http://example.com/image1.png',
+      align: 'center',
+      width: '100%',
+    },
+    data: {
+      description: 'Image 1 description',
+      width: 800,
+      height: 600,
+      createdAt: '2024-08-04',
+    },
+  },
+  {
+    id: '2',
+    type: 'Image',
+    options: {
+      url: 'http://example.com/image2.png',
+      align: 'left',
+      width: '50%',
+    },
+    data: {
+      description: 'Image 2 description',
+      width: 400,
+      height: 300,
+      createdAt: '2024-08-04',
+    },
+  },
+];
+
+export default mockImageBlocks;


### PR DESCRIPTION
Fix for PR: Displaying Images in ImageGrid and Image Information in InfoPanel

### Better Approach for Production:
**Global State Management:**

Instead of prop drilling, consider saving the data into a global state (using Redux or Context API). This approach will make it easier for the ImageGrid and InfoPanel components to access the data and enhance maintainability.

**Routing Configuration:**

Use useParams instead of useRouteMatch in production. While useParams requires more configuration, it is more robust and secure.

**Performance Optimization:**

In a production environment, a long list of images might cause the app to become "laggy." To address this, Utilize React hooks like useMemo and React.memo to wrap pure components, preventing unnecessary re-rendering.
Implement a virtualized list (as mentioned in the [React documentation](https://zh-hant.legacy.reactjs.org/docs/optimizing-performance.html)) to efficiently render only the visible items.

**Lazy Loading Images:**

Implement lazy loading for images. This technique loads images only when they become visible in the viewport, saving users' bandwidth and speeding up the initial page load time.



